### PR TITLE
ci: move Renovate config to the default location

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>statnett/renovate-config"],
-  "forkProcessing": "enabled",
+  "forkProcessing": "enabled"
 }


### PR DESCRIPTION
After looking at the Renovate debug log, I think Renovate needs the configuration to be in the default location to override the organization's default of not being enabled for forked repositories. This is an extract from the logs obtained from https://developer.mend.io/github/statnett/kafka-ops-julie (requires login):

````log
DEBUG: GET https://api.github.com/repos/statnett/kafka-ops-julie/contents/renovate.json = (code=ERR_NON_2XX_3XX_RESPONSE, statusCode=404 retryCount=0, duration=112)
DEBUG: Default config file renovate.json not found in repo
INFO: Repository is a fork and not manually configured - skipping - did you want to run with --fork-processing=enabled?
DEBUG: Removing any stale branches
DEBUG: config.repoIsOnboarded=undefined
````