### PR TITLE
fix: exclude logger implementation to get logs again

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -358,6 +358,14 @@
           <groupId>org.slf4j</groupId>
         </exclusion>
         <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-reload4j</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>ch.qos.reload4j</groupId>
+          <artifactId>reload4j</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>org.bouncycastle</groupId>
           <artifactId>bc-fips</artifactId>
         </exclusion>


### PR DESCRIPTION
```text
SLF4J(W): Class path contains multiple SLF4J providers.
SLF4J(W): Found provider [org.slf4j.reload4j.Reload4jServiceProvider@6b1274d2]
SLF4J(W): Found provider [org.apache.logging.slf4j.SLF4JServiceProvider@7bc1a03d]
SLF4J(W): See https://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J(I): Actual provider is of type [org.slf4j.reload4j.Reload4jServiceProvider@6b1274d2]
```
