### PR TITLE
fix: exclude jackson-module-afterburner

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -401,6 +401,10 @@
           <groupId>com.google.code.findbugs</groupId>
           <artifactId>annotations</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.module</groupId>
+          <artifactId>jackson-module-afterburner</artifactId>
+        </exclusion>
         <exclusion> <!-- from Confluent snapshot repo -->
           <groupId>io.confluent.cloud</groupId>
           <artifactId>events-schema</artifactId>


### PR DESCRIPTION
The `ksqldb-api-client` really is a messy dependency, dragging in a lot of troublesome dependencies. Last one out is `jackson-module-afterburner`, which gives exceptions like these when run in Java >8:

```text
WARNING: Disabling Afterburner deserialization for class com.purbon.kafka.topology.model.PlanMap (field #0; mutator com.fasterxml.jackson.module.afterburner.deser.SettableObjectFieldProperty), due to access error (type java.lang.IllegalAccessError, message=class com.purbon.kafka.topology.model.PlanMap$Access4JacksonDeserializerb2c3dc9e tried to access field com.purbon.kafka.topology.model.PlanMap.plans (com.purbon.kafka.topology.model.PlanMap$Access4JacksonDeserializerb2c3dc9e is in unnamed module of loader com.fasterxml.jackson.module.afterburner.util.MyClassLoader @9ec531; com.purbon.kafka.topology.model.PlanMap is in unnamed module of loader 'app'))
java.lang.IllegalAccessError: class com.purbon.kafka.topology.model.PlanMap$Access4JacksonDeserializerb2c3dc9e tried to access field com.purbon.kafka.topology.model.PlanMap.plans (com.purbon.kafka.topology.model.PlanMap$Access4JacksonDeserializerb2c3dc9e is in unnamed module of loader com.fasterxml.jackson.module.afterburner.util.MyClassLoader @9ec531; com.purbon.kafka.topology.model.PlanMap is in unnamed module of loader 'app')
	at com.purbon.kafka.topology.model.PlanMap$Access4JacksonDeserializerb2c3dc9e.objectField(com/purbon/kafka/topology/model/PlanMap$Access4JacksonDeserializer.java)
	at com.fasterxml.jackson.module.afterburner.deser.SettableObjectFieldProperty.deserializeAndSet(SettableObjectFieldProperty.java:59)
	at com.fasterxml.jackson.module.afterburner.deser.SuperSonicBeanDeserializer.deserialize(SuperSonicBeanDeserializer.java:159)
	at com.fasterxml.jackson.databind.deser.DefaultDeserializationContext.readRootValue(DefaultDeserializationContext.java:342)
	at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:4917)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3725)
	at com.purbon.kafka.topology.serdes.PlanMapSerdes.deserialise(PlanMapSerdes.java:27)
  :
```
