### PR TITLE
fix: allow totally empty state topic

### DIFF
--- a/src/main/java/com/purbon/kafka/topology/backend/kafka/KafkaBackendConsumer.java
+++ b/src/main/java/com/purbon/kafka/topology/backend/kafka/KafkaBackendConsumer.java
@@ -64,6 +64,9 @@ public class KafkaBackendConsumer {
       }
       consumer.commitAsync();
     }
+    if (map.isEmpty()) {
+      return new BackendState();
+    }
     byte[] bytes = chunker.dechunk(new ArrayList<>(map.values()));
     final String json = new String(bytes, StandardCharsets.UTF_8);
     try {

--- a/src/test/java/com/purbon/kafka/topology/integration/backend/KafkaBackendIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/backend/KafkaBackendIT.java
@@ -62,6 +62,10 @@ public class KafkaBackendIT {
   @Test
   public void testExpectedFlow() throws InterruptedException {
 
+    KafkaBackend backend = new KafkaBackend();
+    backend.configure(config);
+    backend.load(); /* Just to check that initial load from empty topic does not fail. */
+
     TopologyAclBinding binding1 =
         TopologyAclBinding.build(
             ResourceType.TOPIC.name(), "foo", "*", "Write", "User:foo", "LITERAL");


### PR DESCRIPTION
This will happen on the first run, when the state topic has just been created, and JulieOps tries to load the topology before it has been saved.

Fix confirmed by extended integration test.