### PR TITLE
chore: replace abandoned s3mock with local-s3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -513,16 +513,10 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.findify</groupId>
-      <artifactId>s3mock_2.13</artifactId>
-      <version>0.2.6</version>
+      <groupId>io.github.robothy</groupId>
+      <artifactId>local-s3-rest</artifactId>
+      <version>1.20</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>javax.xml.bind</groupId>
-          <artifactId>jaxb-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.wiremock</groupId>

--- a/src/test/java/com/purbon/kafka/topology/integration/backend/S3BackendIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/backend/S3BackendIT.java
@@ -41,8 +41,8 @@ public class S3BackendIT {
 
     long time = System.currentTimeMillis();
     String tmpDir = System.getProperty("java.io.tmpdir");
-    Path s3Path = Paths.get(tmpDir, "s3-" + time);
-    api = LocalS3.builder().port(8001).build();
+    String s3Path = Paths.get(tmpDir, "s3-" + time).toString();
+    api = LocalS3.builder().port(8001).dataPath(s3Path).build();
     api.start();
 
     S3Client client =

--- a/src/test/java/com/purbon/kafka/topology/integration/backend/S3BackendIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/backend/S3BackendIT.java
@@ -11,7 +11,6 @@ import com.purbon.kafka.topology.roles.TopologyAclBinding;
 import com.robothy.s3.rest.LocalS3;
 import java.io.IOException;
 import java.net.URI;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashMap;

--- a/src/test/java/com/purbon/kafka/topology/integration/backend/S3BackendIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/backend/S3BackendIT.java
@@ -1,23 +1,16 @@
 package com.purbon.kafka.topology.integration.backend;
 
 import static com.purbon.kafka.topology.CommandLineInterface.BROKERS_OPTION;
-import static com.purbon.kafka.topology.Constants.JULIE_S3_BUCKET;
-import static com.purbon.kafka.topology.Constants.JULIE_S3_ENDPOINT;
-import static com.purbon.kafka.topology.Constants.JULIE_S3_REGION;
+import static com.purbon.kafka.topology.Constants.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.AnonymousAWSCredentials;
-import com.amazonaws.client.builder.AwsClientBuilder;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
-import com.amazonaws.services.s3.model.Region;
 import com.purbon.kafka.topology.Configuration;
 import com.purbon.kafka.topology.backend.BackendState;
 import com.purbon.kafka.topology.backend.S3Backend;
 import com.purbon.kafka.topology.roles.TopologyAclBinding;
-import io.findify.s3mock.S3Mock;
+import com.robothy.s3.rest.LocalS3;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
@@ -28,10 +21,14 @@ import org.apache.kafka.common.resource.ResourceType;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 
 public class S3BackendIT {
 
-  private S3Mock api;
+  private LocalS3 api;
   private Map<String, String> cliOps;
 
   private static final String TEST_BUCKET = "testbucket";
@@ -45,19 +42,17 @@ public class S3BackendIT {
     long time = System.currentTimeMillis();
     String tmpDir = System.getProperty("java.io.tmpdir");
     Path s3Path = Paths.get(tmpDir, "s3-" + time);
-    api = S3Mock.create(8001, s3Path.toFile().getAbsolutePath());
+    api = LocalS3.builder().port(8001).build();
+    // api = S3Mock.create(8001, s3Path.toFile().getAbsolutePath());
     api.start();
 
-    AnonymousAWSCredentials credentials = new AnonymousAWSCredentials();
-    AwsClientBuilder.EndpointConfiguration endpointConfiguration =
-        new AwsClientBuilder.EndpointConfiguration(
-            TEST_ENDPOINT, Region.US_Standard.getFirstRegionId());
-    AmazonS3 client =
-        AmazonS3ClientBuilder.standard()
-            .withEndpointConfiguration(endpointConfiguration)
-            .withCredentials(new AWSStaticCredentialsProvider(credentials))
+    S3Client client =
+        S3Client.builder()
+            .region(Region.US_WEST_2)
+            .endpointOverride(URI.create(TEST_ENDPOINT))
+            .credentialsProvider(AnonymousCredentialsProvider.create())
             .build();
-    client.createBucket(TEST_BUCKET);
+    client.createBucket(CreateBucketRequest.builder().bucket(TEST_BUCKET).build());
   }
 
   @After

--- a/src/test/java/com/purbon/kafka/topology/integration/backend/S3BackendIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/backend/S3BackendIT.java
@@ -43,7 +43,6 @@ public class S3BackendIT {
     String tmpDir = System.getProperty("java.io.tmpdir");
     Path s3Path = Paths.get(tmpDir, "s3-" + time);
     api = LocalS3.builder().port(8001).build();
-    // api = S3Mock.create(8001, s3Path.toFile().getAbsolutePath());
     api.start();
 
     S3Client client =


### PR DESCRIPTION
The [s3mock project](https://github.com/findify/s3mock) was archived long ago.  I suspect this library is the reason we cannot upgrade the AWS packages. This PR replaces s3mock with [local-s3](https://github.com/Robothy/local-s3) in an attempt to fix.

Disclaimer: I have no idea what this test does.