### PR TITLE
fix: exclude troublesome dependency io.confluent:broker-plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -354,6 +354,10 @@
       <version>${ksqldb.client.version}</version>
       <exclusions>
         <exclusion>
+          <groupId>io.confluent</groupId>
+          <artifactId>broker-plugins</artifactId>
+        </exclusion>
+        <exclusion>
           <artifactId>slf4j-log4j12</artifactId>
           <groupId>org.slf4j</groupId>
         </exclusion>

--- a/src/main/java/com/purbon/kafka/topology/utils/CCloudUtils.java
+++ b/src/main/java/com/purbon/kafka/topology/utils/CCloudUtils.java
@@ -54,13 +54,13 @@ public class CCloudUtils {
             + principal.getPrincipalType().name()
             + ":"
             + numericServiceAccountId);
-      return TopologyAclBinding.build(
-          binding.getResourceType(),
-          binding.getResourceName(),
-          binding.getHost(),
-          binding.getOperation(),
-          principal.toMappedPrincipalString(numericServiceAccountId),
-          binding.getPattern());
+    return TopologyAclBinding.build(
+        binding.getResourceType(),
+        binding.getResourceName(),
+        binding.getHost(),
+        binding.getOperation(),
+        principal.toMappedPrincipalString(numericServiceAccountId),
+        binding.getPattern());
   }
 
   public Map<String, Long> initializeLookupTable(CCloudApi cli) throws IOException {


### PR DESCRIPTION
This one, which comes from ksqldb-api-client, drags in _a_lot_, including the entire kafka-server.