### PR TITLE
test: replace testcontainers with k3a-embedded for first test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -276,6 +276,7 @@
     <jedis.version>5.2.0</jedis.version>
     <jinjava.version>2.7.4</jinjava.version>
     <junit.version>4.13.2</junit.version>
+    <k3a.embedded.version>0.5.9+3.9.0</k3a.embedded.version>
     <kafka.version>3.9.0</kafka.version>
     <ksqldb.client.version>7.9.0</ksqldb.client.version>
     <ksqldb.version>0.27.1</ksqldb.version>
@@ -527,6 +528,18 @@
       <artifactId>wiremock</artifactId>
       <version>3.12.1</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>no.shhsoft</groupId>
+      <artifactId>k3a-embedded</artifactId>
+      <version>${k3a.embedded.version}</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.module</groupId>
+          <artifactId>jackson-module-scala_2.13</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
   </dependencies>

--- a/src/test/java/com/purbon/kafka/topology/integration/AccessControlManagerIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/AccessControlManagerIT.java
@@ -1,27 +1,28 @@
 package com.purbon.kafka.topology.integration;
 
-import static com.purbon.kafka.topology.CommandLineInterface.*;
+import static com.purbon.kafka.topology.CommandLineInterface.BROKERS_OPTION;
 import static com.purbon.kafka.topology.Constants.*;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
-import com.purbon.kafka.topology.AccessControlManager;
-import com.purbon.kafka.topology.BackendController;
-import com.purbon.kafka.topology.Configuration;
-import com.purbon.kafka.topology.ExecutionPlan;
-import com.purbon.kafka.topology.TestTopologyBuilder;
+import com.purbon.kafka.topology.*;
 import com.purbon.kafka.topology.api.adminclient.AclBuilder;
 import com.purbon.kafka.topology.api.adminclient.TopologyBuilderAdminClient;
-import com.purbon.kafka.topology.integration.containerutils.ContainerFactory;
 import com.purbon.kafka.topology.integration.containerutils.ContainerTestUtils;
-import com.purbon.kafka.topology.integration.containerutils.SaslPlaintextKafkaContainer;
-import com.purbon.kafka.topology.model.*;
+import com.purbon.kafka.topology.integration.containerutils.SaslPlaintextEmbeddedKafka;
 import com.purbon.kafka.topology.model.Impl.ProjectImpl;
 import com.purbon.kafka.topology.model.Impl.TopologyImpl;
+import com.purbon.kafka.topology.model.Platform;
+import com.purbon.kafka.topology.model.Project;
+import com.purbon.kafka.topology.model.Topic;
+import com.purbon.kafka.topology.model.Topology;
 import com.purbon.kafka.topology.model.users.*;
-import com.purbon.kafka.topology.model.users.platform.*;
+import com.purbon.kafka.topology.model.users.platform.ControlCenter;
+import com.purbon.kafka.topology.model.users.platform.ControlCenterInstance;
+import com.purbon.kafka.topology.model.users.platform.SchemaRegistry;
+import com.purbon.kafka.topology.model.users.platform.SchemaRegistryInstance;
 import com.purbon.kafka.topology.roles.SimpleAclsProvider;
 import com.purbon.kafka.topology.roles.TopologyAclBinding;
 import com.purbon.kafka.topology.roles.acls.AclsBindingsBuilder;
@@ -42,7 +43,7 @@ import org.mockito.junit.MockitoRule;
 
 public class AccessControlManagerIT {
 
-  private static SaslPlaintextKafkaContainer container;
+  private static SaslPlaintextEmbeddedKafka kafka;
   private static AdminClient kafkaAdminClient;
   private TopologyBuilderAdminClient topologyAdminClient;
   private AccessControlManager accessControlManager;
@@ -57,20 +58,20 @@ public class AccessControlManagerIT {
 
   @BeforeClass
   public static void setup() {
-    container = ContainerFactory.fetchSaslKafkaContainer(System.getProperty("cp.version"));
-    container.start();
+    kafka = new SaslPlaintextEmbeddedKafka();
+    kafka.start();
   }
 
   @AfterClass
   public static void teardown() {
-    container.stop();
+    kafka.stop();
   }
 
   @Before
   public void before() throws IOException {
-    kafkaAdminClient = ContainerTestUtils.getSaslJulieAdminClient(container);
+    kafkaAdminClient = ContainerTestUtils.getSaslJulieAdminClient(kafka);
     topologyAdminClient = new TopologyBuilderAdminClient(kafkaAdminClient);
-    ContainerTestUtils.resetAcls(container);
+    ContainerTestUtils.resetAcls(kafka);
     TestUtils.deleteStateFile();
 
     this.cs = new BackendController();

--- a/src/test/java/com/purbon/kafka/topology/integration/containerutils/ContainerTestUtils.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/containerutils/ContainerTestUtils.java
@@ -39,6 +39,10 @@ public final class ContainerTestUtils {
     return getSaslJulieAdminClient(container.getBootstrapServers());
   }
 
+  public static AdminClient getSaslJulieAdminClient(final SaslPlaintextEmbeddedKafka kafka) {
+    return getSaslJulieAdminClient(kafka.getBootstrapServers());
+  }
+
   public static AdminClient getSaslJulieAdminClient(final String boostrapServers) {
     return AdminClient.create(getSaslConfig(boostrapServers, JULIE_USERNAME, JULIE_PASSWORD));
   }
@@ -120,7 +124,15 @@ public final class ContainerTestUtils {
   }
 
   public static void resetAcls(AlternativeKafkaContainer container) {
-    AdminClient admin = getSaslSuperUserAdminClient(container.getBootstrapServers());
+    resetAcls(container.getBootstrapServers());
+  }
+
+  public static void resetAcls(SaslPlaintextEmbeddedKafka kafka) {
+    resetAcls(kafka.getBootstrapServers());
+  }
+
+  private static void resetAcls(String bootstrapServers) {
+    AdminClient admin = getSaslSuperUserAdminClient(bootstrapServers);
     clearAllAcls(admin);
     setupJulieAcls(admin);
   }

--- a/src/test/java/com/purbon/kafka/topology/integration/containerutils/SaslPlaintextEmbeddedKafka.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/containerutils/SaslPlaintextEmbeddedKafka.java
@@ -1,0 +1,117 @@
+package com.purbon.kafka.topology.integration.containerutils;
+
+import java.util.HashMap;
+import java.util.Map;
+import no.shhsoft.k3aembedded.K3aEmbedded;
+import org.apache.kafka.metadata.authorizer.StandardAuthorizer;
+import org.testcontainers.Testcontainers;
+
+public final class SaslPlaintextEmbeddedKafka {
+
+  private static final String[] EXTRA_USERS =
+      new String[] {
+        ContainerTestUtils.NO_ACCESS_USERNAME,
+        ContainerTestUtils.PRODUCER_USERNAME,
+        ContainerTestUtils.CONSUMER_USERNAME,
+        ContainerTestUtils.OTHER_PRODUCER_USERNAME,
+        ContainerTestUtils.OTHER_CONSUMER_USERNAME,
+        ContainerTestUtils.STREAMS_USERNAME,
+      };
+  private K3aEmbedded kafka;
+
+  public void start() {
+    final String jaasLoginLine = createJaasLoginLine();
+    final Map<String, Object> map = new HashMap<>();
+    map.put("listener.name.broker.plain.sasl.jaas.config", jaasLoginLine);
+    map.put("listener.name.controller.plain.sasl.jaas.config", jaasLoginLine);
+    map.put("listener.name.sasl_plaintext.sasl.enabled.mechanisms", "PLAIN");
+    map.put("listener.name.sasl_plaintext.plain.sasl.jaas.config", jaasLoginLine);
+    map.put("listener.name.testcontainers.sasl.enabled.mechanisms", "PLAIN");
+    map.put("listener.name.testcontainers.plain.sasl.jaas.config", jaasLoginLine);
+    map.put("sasl.mechanism.inter.broker.protocol", "PLAIN");
+    map.put("sasl.mechanism.controller.protocol", "PLAIN");
+    map.put("sasl.enabled.mechanisms", "PLAIN");
+    map.put("super.users", "User:kafka");
+    map.put(
+        "listener.security.protocol.map",
+        "BROKER:SASL_PLAINTEXT, CONTROLLER:SASL_PLAINTEXT, SASL_PLAINTEXT:SASL_PLAINTEXT, TESTCONTAINERS:SASL_PLAINTEXT");
+    map.put("authorizer.class.name", StandardAuthorizer.class.getName());
+    kafka =
+        new K3aEmbedded.Builder()
+            .kraftMode(true)
+            .additionalPorts(2)
+            .additionalConfiguration(map)
+            .additionalListenerWithPortIndex("SASL_PLAINTEXT", "SASL_PLAINTEXT", 0)
+            .additionalListenerWithPortIndex("TESTCONTAINERS", "SASL_PLAINTEXT", 1)
+            .additionalConfigurationProvider(
+                () -> {
+                  return Map.of(
+                      "advertised.listeners",
+                      "BROKER://:"
+                          + kafka.getBrokerPort()
+                          + ","
+                          + "CONTROLLER://:"
+                          + kafka.getControllerPort()
+                          + ","
+                          + "SASL_PLAINTEXT://:"
+                          + kafka.getAdditionalPort(0)
+                          + ","
+                          + "TESTCONTAINERS://host.testcontainers.internal:"
+                          + kafka.getAdditionalPort(1));
+                })
+            .build();
+    kafka.start();
+    Testcontainers.exposeHostPorts(kafka.getAdditionalPort(1));
+  }
+
+  public void stop() {
+    kafka.stop();
+  }
+
+  public String getBootstrapServers() {
+    return kafka.getBootstrapServersForAdditionalPort(0);
+  }
+
+  public String getBootstrapServersForTestContainers() {
+    return "TESTCONTAINERS://host.testcontainers.internal:" + kafka.getAdditionalPort(1);
+  }
+
+  private String createJaasLoginLine() {
+    /* Precondition: No usernames or passwords contain characters that need special handling for JAAS config. */
+    final StringBuilder sb = new StringBuilder();
+    sb.append("org.apache.kafka.common.security.plain.PlainLoginModule required username=\"");
+    sb.append(ContainerTestUtils.DEFAULT_SUPER_USERNAME);
+    sb.append("\" password=\"");
+    sb.append(ContainerTestUtils.DEFAULT_SUPER_USERNAME);
+    sb.append("\" user_");
+    sb.append(ContainerTestUtils.DEFAULT_SUPER_USERNAME);
+    sb.append("=\"");
+    sb.append(ContainerTestUtils.DEFAULT_SUPER_USERNAME);
+    sb.append("\" user_");
+    sb.append(ContainerTestUtils.JULIE_USERNAME);
+    sb.append("=\"");
+    sb.append(ContainerTestUtils.JULIE_PASSWORD);
+    sb.append("\"");
+    for (final String userAndPassword : EXTRA_USERS) {
+      assertValidUsernameAndPassword(userAndPassword);
+      sb.append(" user_");
+      sb.append(userAndPassword);
+      sb.append("=\"");
+      sb.append(userAndPassword);
+      sb.append("\"");
+    }
+    sb.append(";");
+    return sb.toString();
+  }
+
+  private static String assertValidUsernameAndPassword(final String s) {
+    /* Enforcing, in order to not have to deal with escaping for the JAAS config. */
+    for (final char c : s.toCharArray()) {
+      if (!(c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9' || c == '-')) {
+        throw new RuntimeException(
+            "Only letters, digits and hyphens allowed in usernames and passwords.");
+      }
+    }
+    return s;
+  }
+}


### PR DESCRIPTION
This is the first in a series of PRs to replace [testcontainers](https://github.com/testcontainers/testcontainers-java/) with [k3a-embedded](https://github.com/sverrehu/k3a-embedded) for integration tests.

This PR alone doesn't do much, but local testing indicates that using k3a-embedded for all tests will reduce the run time by about 40% (from 13 to 8 minutes).

The major part of this PR is the introduction of the `SaslPlaintextEmbeddedKafka` class. Subequent PRs will rely on this class, and thus be smaller.