### PR TITLE
fix: use CP v8 with KRaft, not ZK, for testcontainers

### DIFF
--- a/src/main/java/com/purbon/kafka/topology/api/adminclient/TopologyBuilderAdminClient.java
+++ b/src/main/java/com/purbon/kafka/topology/api/adminclient/TopologyBuilderAdminClient.java
@@ -251,8 +251,12 @@ public class TopologyBuilderAdminClient {
         quotas.stream()
             .map(f -> new QuotasClientBindingsBuilder(f).build())
             .collect(Collectors.toList());
-
-    this.adminClient.alterClientQuotas(lstQuotasAlteration).all();
+    try {
+      this.adminClient.alterClientQuotas(lstQuotasAlteration).all().get();
+    } catch (ExecutionException | InterruptedException e) {
+      LOGGER.error(e);
+      throw new RuntimeException(e);
+    }
   }
 
   public void removeQuotasPrincipal(Collection<User> users) {

--- a/src/main/java/com/purbon/kafka/topology/api/adminclient/TopologyBuilderAdminClient.java
+++ b/src/main/java/com/purbon/kafka/topology/api/adminclient/TopologyBuilderAdminClient.java
@@ -272,7 +272,12 @@ public class TopologyBuilderAdminClient {
                                 Optional.empty()))
                         .build())
             .collect(Collectors.toList());
-    this.adminClient.alterClientQuotas(lstQuotasRemove);
+    try {
+      this.adminClient.alterClientQuotas(lstQuotasRemove).all().get();
+    } catch (ExecutionException | InterruptedException e) {
+      LOGGER.error(e);
+      throw new RuntimeException(e);
+    }
   }
 
   public Map<ClientQuotaEntity, Map<String, Double>> describeClientQuotas()

--- a/src/test/java/com/purbon/kafka/topology/integration/QuotasManagerIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/QuotasManagerIT.java
@@ -202,7 +202,12 @@ public class QuotasManagerIT {
     assertTrue(action instanceof CreateQuotasAction);
 
     plan.getActions().clear();
-
+    try {
+      /* with CP 8.0.0 there are timing issues between updating quotas and querying them. */
+      Thread.sleep(500);
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
     // Test NOOP plan update
     quotasManager.updatePlan(topology, plan);
     plan.run();

--- a/src/test/java/com/purbon/kafka/topology/integration/QuotasManagerIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/QuotasManagerIT.java
@@ -29,7 +29,10 @@ import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.common.quota.ClientQuotaEntity;
 import org.apache.kafka.common.quota.ClientQuotaFilter;
 import org.junit.*;
+import org.junit.runner.OrderWith;
+import org.junit.runner.manipulation.Alphanumeric;
 
+@OrderWith(Alphanumeric.class)
 public class QuotasManagerIT {
 
   private static SaslPlaintextKafkaContainer container;

--- a/src/test/java/com/purbon/kafka/topology/integration/containerutils/AlternativeKafkaContainer.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/containerutils/AlternativeKafkaContainer.java
@@ -1,9 +1,8 @@
 package com.purbon.kafka.topology.integration.containerutils;
 
-import com.github.dockerjava.api.command.ExecCreateCmdResponse;
 import com.github.dockerjava.api.command.InspectContainerResponse;
 import java.nio.charset.StandardCharsets;
-import java.util.concurrent.TimeUnit;
+import org.apache.kafka.common.Uuid;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.images.builder.Transferable;
 import org.testcontainers.utility.DockerImageName;
@@ -16,9 +15,10 @@ public class AlternativeKafkaContainer extends GenericContainer<AlternativeKafka
 
   private static final String STARTER_SCRIPT = "/testcontainers_start.sh";
   public static final String INTERNAL_LISTENER_NAME = "BROKER";
+  public static final String CONTROLLER_LISTENER_NAME = "CONTROLLER";
   public static final int KAFKA_PORT = 9092;
   public static final int KAFKA_INTERNAL_PORT = 9093;
-  public static final int ZOOKEEPER_PORT = 2181;
+  public static final int KAFKA_CONTROLLER_PORT = 9090;
   /* Note difference between 0.0.0.0 and localhost: The former will be replaced by the container IP. */
   private static final String LISTENERS =
       "PLAINTEXT://0.0.0.0:"
@@ -26,20 +26,31 @@ public class AlternativeKafkaContainer extends GenericContainer<AlternativeKafka
           + ","
           + INTERNAL_LISTENER_NAME
           + "://127.0.0.1:"
-          + KAFKA_INTERNAL_PORT;
+          + KAFKA_INTERNAL_PORT
+          + ","
+          + CONTROLLER_LISTENER_NAME
+          + "://127.0.0.1:"
+          + KAFKA_CONTROLLER_PORT;
   private static final int PORT_NOT_ASSIGNED = -1;
   private int port = PORT_NOT_ASSIGNED;
-  protected String externalZookeeperConnect = null;
 
   public AlternativeKafkaContainer(final DockerImageName dockerImageName) {
     super(dockerImageName);
-    withExposedPorts(KAFKA_PORT);
+    withExposedPorts(KAFKA_PORT, KAFKA_CONTROLLER_PORT);
     withEnv("KAFKA_LISTENERS", LISTENERS);
     withEnv(
         "KAFKA_LISTENER_SECURITY_PROTOCOL_MAP",
-        "PLAINTEXT:PLAINTEXT," + INTERNAL_LISTENER_NAME + ":PLAINTEXT");
+        "PLAINTEXT:PLAINTEXT,"
+            + INTERNAL_LISTENER_NAME
+            + ":PLAINTEXT,"
+            + CONTROLLER_LISTENER_NAME
+            + ":PLAINTEXT");
     withEnv("KAFKA_INTER_BROKER_LISTENER_NAME", INTERNAL_LISTENER_NAME);
-    withEnv("KAFKA_BROKER_ID", "1");
+    withEnv("KAFKA_NODE_ID", "1");
+    withEnv("KAFKA_PROCESS_ROLES", "broker, controller");
+    withEnv("KAFKA_CONTROLLER_QUORUM_VOTERS", "1@localhost:" + KAFKA_CONTROLLER_PORT);
+    withEnv("KAFKA_CONTROLLER_LISTENER_NAMES", CONTROLLER_LISTENER_NAME);
+    withEnv("CLUSTER_ID", Uuid.randomUuid().toString());
     withEnv("KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", "1");
     withEnv("KAFKA_OFFSETS_TOPIC_NUM_PARTITIONS", "1");
     withEnv("KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", "1");
@@ -64,9 +75,6 @@ public class AlternativeKafkaContainer extends GenericContainer<AlternativeKafka
   protected final void doStart() {
     withCommand(
         "sh", "-c", "while [ ! -f " + STARTER_SCRIPT + " ]; do sleep 0.1; done; " + STARTER_SCRIPT);
-    if (externalZookeeperConnect == null) {
-      addExposedPort(ZOOKEEPER_PORT);
-    }
     beforeStart();
     super.doStart();
   }
@@ -83,15 +91,13 @@ public class AlternativeKafkaContainer extends GenericContainer<AlternativeKafka
       return;
     }
     beforeStartupPreparations();
-    final String zookeeperConnect =
-        externalZookeeperConnect != null ? externalZookeeperConnect : startZookeeper();
-    createStartupScript(zookeeperConnect);
+    createStartupScript();
   }
 
   /** Subclasses may override. */
   protected void beforeStartupPreparations() {}
 
-  private void createStartupScript(final String zookeeperConnect) {
+  private void createStartupScript() {
     final String listeners = getEnvMap().get("KAFKA_LISTENERS");
     if (listeners == null) {
       throw new RuntimeException("Need environment variable KAFKA_LISTENERS");
@@ -106,14 +112,12 @@ public class AlternativeKafkaContainer extends GenericContainer<AlternativeKafka
     final String startupScript =
         overrideStartupScript(
             "#!/bin/bash\n"
-                + "export KAFKA_ZOOKEEPER_CONNECT='"
-                + zookeeperConnect
-                + "'\n"
                 + "export KAFKA_ADVERTISED_LISTENERS='"
                 + advertisedListeners
                 + "'\n"
                 + ". /etc/confluent/docker/bash-config\n"
                 + "/etc/confluent/docker/configure\n"
+                + "/etc/confluent/docker/ensure\n"
                 + "/etc/confluent/docker/launch\n");
     copyFileToContainer(
         Transferable.of(startupScript.getBytes(StandardCharsets.UTF_8), 0755), STARTER_SCRIPT);
@@ -129,30 +133,9 @@ public class AlternativeKafkaContainer extends GenericContainer<AlternativeKafka
     return startupScript;
   }
 
-  private String startZookeeper() {
-    final ExecCreateCmdResponse execCreateCmdResponse =
-        dockerClient
-            .execCreateCmd(getContainerId())
-            .withCmd(
-                "sh",
-                "-c",
-                "echo '*** Starting Zookeeper'\n"
-                    + "printf 'clientPort="
-                    + ZOOKEEPER_PORT
-                    + "\n"
-                    + "dataDir=/var/lib/zookeeper/data\ndataLogDir=/var/lib/zookeeper/log' > zookeeper.properties\n"
-                    + "zookeeper-server-start zookeeper.properties\n")
-            .withAttachStderr(true)
-            .withAttachStdout(true)
-            .exec();
-    try {
-      dockerClient
-          .execStartCmd(execCreateCmdResponse.getId())
-          .start()
-          .awaitStarted(10, TimeUnit.SECONDS);
-    } catch (final InterruptedException e) {
-      throw new RuntimeException(e);
-    }
-    return "127.0.0.1:" + ZOOKEEPER_PORT;
+  @Override
+  protected void containerIsStarted(InspectContainerResponse containerInfo) {
+    super.containerIsStarted(containerInfo);
+    System.out.println(getLogs());
   }
 }

--- a/src/test/java/com/purbon/kafka/topology/integration/containerutils/ContainerTestUtils.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/containerutils/ContainerTestUtils.java
@@ -31,7 +31,7 @@ public final class ContainerTestUtils {
   public static final String OTHER_CONSUMER_USERNAME = "other-consumer";
   public static final String STREAMS_USERNAME = "streamsapp";
   public static final int NUM_JULIE_INITIAL_ACLS = 11;
-  static final String DEFAULT_CP_KAFKA_VERSION = "7.9.0";
+  static final String DEFAULT_CP_KAFKA_VERSION = "8.0.0";
 
   private ContainerTestUtils() {}
 


### PR DESCRIPTION
The `QuotasManagerIT` test is flaky with CP 8.0.0. Not reproducible in Idea, so I did not spend too much time researcing the reason, since we do not use quotas. Instead i did the following to "fix":

* Give test methods a predictable run order
* Add a small delay at a criticle part of the test
* Make sure quota operations do not return before they are completed
