### PR TITLE
chore: make TopologyAclBinding.toString more readable

### DIFF
--- a/src/main/java/com/purbon/kafka/topology/roles/TopologyAclBinding.java
+++ b/src/main/java/com/purbon/kafka/topology/roles/TopologyAclBinding.java
@@ -159,26 +159,21 @@ public class TopologyAclBinding implements Comparable<TopologyAclBinding> {
 
   @Override
   public String toString() {
-    return "\'"
+    return "{'"
         + resourceType
-        + '\''
-        + ", '"
+        + "', '"
         + resourceName
-        + '\''
-        + ", '"
+        + "', '"
         + host
-        + '\''
-        + ", '"
+        + "', '"
         + operation
-        + '\''
-        + ", '"
+        + "', '"
         + principal
-        + '\''
-        + ", '"
+        + "', '"
         + pattern
-        + '\''
+        + "', '"
         + permissionType
-        + '\'';
+        + "'}";
   }
 
   public String getResourceName() {

--- a/src/main/java/com/purbon/kafka/topology/roles/TopologyAclBinding.java
+++ b/src/main/java/com/purbon/kafka/topology/roles/TopologyAclBinding.java
@@ -161,19 +161,8 @@ public class TopologyAclBinding implements Comparable<TopologyAclBinding> {
   @Override
   public String toString() {
     return "{'"
-        + resourceType
-        + "', '"
-        + resourceName
-        + "', '"
-        + host
-        + "', '"
-        + operation
-        + "', '"
-        + principal
-        + "', '"
-        + pattern
-        + "', '"
-        + permissionType
+        + StringUtils.joinWith(
+            "', '", resourceType, resourceName, host, operation, principal, pattern, permissionType)
         + "'}";
   }
 


### PR DESCRIPTION
Recent changes lack a comma before `permissionType`, making it hard to spot that this value was empty when it should have been ALLOW. This PR adds that comma, and also encapsulates the "object" in curly braces to make it easier to split up a long string of such objects, ref the "wall of text" that we see in our error messages.