### PR TITLE
fix: make permission type ALLOW by default

### DIFF
--- a/src/main/java/com/purbon/kafka/topology/roles/TopologyAclBinding.java
+++ b/src/main/java/com/purbon/kafka/topology/roles/TopologyAclBinding.java
@@ -5,6 +5,7 @@ import com.purbon.kafka.topology.api.ccloud.response.KafkaAclResponse;
 import com.purbon.kafka.topology.api.mds.RequestScope;
 import java.util.Objects;
 import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.common.acl.AccessControlEntry;
 import org.apache.kafka.common.acl.AclBinding;
 import org.apache.kafka.common.resource.ResourcePattern;
@@ -46,7 +47,7 @@ public class TopologyAclBinding implements Comparable<TopologyAclBinding> {
     this.operation = operation;
     this.principal = principal;
     this.pattern = pattern;
-    this.permissionType = permissionType;
+    this.permissionType = StringUtils.isBlank(permissionType) ? "ALLOW" : permissionType;
     this.aclBindingOptional = Optional.empty();
   }
 
@@ -59,7 +60,7 @@ public class TopologyAclBinding implements Comparable<TopologyAclBinding> {
    * @param operation an operations to be processed
    * @param principal The selected principal
    * @param pattern the pattern used to mach this acl
-   * @return A contructed TopologyAclBinding object
+   * @return A constructed TopologyAclBinding object
    */
   public static TopologyAclBinding build(
       String resourceTypeString,


### PR DESCRIPTION
`permissionType` was recently [introduced](https://github.com/statnett/kafka-ops-julie/pull/412/files#diff-31894b8775eb485e30fae82c784b4b3f04fd04c1b86ca6824829c67e79c43318R23) in `TopologyAclBinding`. It defaults to an empty string, which is a problem when mixing state generated _before_ this change (will get a blank string) with state read from the cluster _after_ this change (will get "ALLOW").

If state verification is enabled, this will lead to startup failures complaining that the state in the cluster is not compatible with the state in the state store.

This PR changes the default to ALLOW, to be backwards compatible with old state objects.
