### PR TITLE
feat: send log messages to stderr, not stdout

### DIFF
--- a/src/main/conf/log4j2.yml
+++ b/src/main/conf/log4j2.yml
@@ -4,6 +4,7 @@ Configuration:
   appenders:
     Console:
       name: LogToConsole
+      target: SYSTEM_ERR
       PatternLayout:
         Pattern: "[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c{1} - %msg%n"
 

--- a/src/main/resources/log4j2.yml
+++ b/src/main/resources/log4j2.yml
@@ -4,6 +4,7 @@ configuration:
   appenders:
     console:
       name: Console
+      target: SYSTEM_ERR
       patternLayout:
         Pattern: "[%-5level] %d{HH:mm:ss.SSS} [%t] %c{1} - %msg%n"
 

--- a/src/test/resources/log4j2.yml
+++ b/src/test/resources/log4j2.yml
@@ -4,6 +4,7 @@ configuration:
   appenders:
     console:
       name: Console
+      target: SYSTEM_ERR
       patternLayout:
         Pattern: "[%-5level] %d{HH:mm:ss.SSS} [%t] %c{1} - %msg%n"
 


### PR DESCRIPTION
This will make it possible to parse JSON output from the program without having it cluttered with unparsable log messages.