### PR TITLE
feat: add support for backup principal

### DIFF
--- a/src/main/java/com/purbon/kafka/topology/AccessControlManager.java
+++ b/src/main/java/com/purbon/kafka/topology/AccessControlManager.java
@@ -212,6 +212,9 @@ public class AccessControlManager implements ExecutionPlanUpdater {
     for (Topic topic : topics) {
       final String fullTopicName = topic.toString();
       Set<Consumer> consumers = new HashSet(topic.getConsumers());
+      if (topic.isBackupWanted()) {
+        consumers.add(new Consumer(config.getJulieBackupPrincipal()));
+      }
       if (includeProjectLevel) {
         consumers.addAll(project.getConsumers());
       }

--- a/src/main/java/com/purbon/kafka/topology/Configuration.java
+++ b/src/main/java/com/purbon/kafka/topology/Configuration.java
@@ -558,6 +558,10 @@ public class Configuration {
     return julieInstanceId;
   }
 
+  public String getJulieBackupPrincipal() {
+    return getString(JULIE_BACKUP_PRINCIPAL);
+  }
+
   private String julieInstanceId = "";
   private static final int defaultJulieInstanceIDLength = 10;
 

--- a/src/main/java/com/purbon/kafka/topology/Constants.java
+++ b/src/main/java/com/purbon/kafka/topology/Constants.java
@@ -175,4 +175,6 @@ public final class Constants {
 
   public static final String JULIE_HTTP_RETRY_TIMES = "julie.http.retry.times";
   public static final String JULIE_HTTP_BACKOFF_TIME_MS = "julie.http.retry.backoff.time.ms";
+
+  public static final String JULIE_BACKUP_PRINCIPAL = "julie.backup.principal";
 }

--- a/src/main/java/com/purbon/kafka/topology/model/Topic.java
+++ b/src/main/java/com/purbon/kafka/topology/model/Topic.java
@@ -192,6 +192,25 @@ public class Topic implements Cloneable {
     this.consumers.addAll(consumers);
   }
 
+  @JsonIgnore
+  public boolean isBackupWanted() {
+    if (metadata == null) {
+      return false;
+    }
+    final String allowBackupString = metadata.get("allow-backup");
+    if (allowBackupString == null) {
+      return false;
+    }
+    if ("true".equals(allowBackupString)) {
+      return true;
+    }
+    if ("false".equals(allowBackupString)) {
+      return false;
+    }
+    throw new IllegalArgumentException(
+        "allow-backup must be true or false, not " + allowBackupString);
+  }
+
   public void setProducers(List<Producer> producers) {
     this.producers.clear();
     this.producers.addAll(producers);

--- a/src/test/java/com/purbon/kafka/topology/integration/AclProducerAndConsumerIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/AclProducerAndConsumerIT.java
@@ -28,6 +28,7 @@ public final class AclProducerAndConsumerIT {
             .withUser(ContainerTestUtils.NO_ACCESS_USERNAME)
             .withUser(ContainerTestUtils.PRODUCER_USERNAME)
             .withUser(ContainerTestUtils.CONSUMER_USERNAME)
+            .withUser(ContainerTestUtils.BACKUP_USERNAME)
             .withUser(ContainerTestUtils.OTHER_PRODUCER_USERNAME)
             .withUser(ContainerTestUtils.OTHER_CONSUMER_USERNAME);
     container.start();
@@ -69,6 +70,21 @@ public final class AclProducerAndConsumerIT {
     try (final TestConsumer consumer =
         TestConsumer.create(container, ContainerTestUtils.NO_ACCESS_USERNAME, CONSUMER_GROUP)) {
       consumer.consumeForAWhile(TOPIC, null);
+    }
+  }
+
+  @Test(expected = TopicAuthorizationException.class)
+  public void shouldNotBackupWithoutPermission() {
+    try (final TestConsumer consumer =
+        TestConsumer.create(container, ContainerTestUtils.BACKUP_USERNAME, CONSUMER_GROUP)) {
+      consumer.consumeForAWhile(TOPIC, null);
+    }
+  }
+
+  public void shouldBackupWithPermission() {
+    try (final TestConsumer consumer =
+        TestConsumer.create(container, ContainerTestUtils.BACKUP_USERNAME, CONSUMER_GROUP)) {
+      consumer.consumeForAWhile(OTHER_TOPIC, null);
     }
   }
 

--- a/src/test/java/com/purbon/kafka/topology/integration/StreamsAclIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/StreamsAclIT.java
@@ -34,6 +34,7 @@ public final class StreamsAclIT {
         new SaslPlaintextKafkaContainer()
             .withUser(ContainerTestUtils.PRODUCER_USERNAME)
             .withUser(ContainerTestUtils.CONSUMER_USERNAME)
+            .withUser(ContainerTestUtils.BACKUP_USERNAME)
             .withUser(ContainerTestUtils.STREAMS_USERNAME);
     container.start();
   }
@@ -71,6 +72,25 @@ public final class StreamsAclIT {
 
   @Test
   public void testSimpleStream() {
+    simpleStream(ContainerTestUtils.CONSUMER_USERNAME);
+  }
+
+  @Test
+  public void testStreamWithInternalTopics() {
+    streamWithInternalTopics(ContainerTestUtils.CONSUMER_USERNAME);
+  }
+
+  @Test
+  public void testBackupOfSimpleStream() {
+    simpleStream(ContainerTestUtils.BACKUP_USERNAME);
+  }
+
+  @Test
+  public void testBackupOfStreamWithInternalTopics() {
+    streamWithInternalTopics(ContainerTestUtils.BACKUP_USERNAME);
+  }
+
+  public void simpleStream(String consumerUsername) {
     Set<String> values;
     try (final TestProducer producer =
         TestProducer.create(container, ContainerTestUtils.PRODUCER_USERNAME)) {
@@ -84,7 +104,7 @@ public final class StreamsAclIT {
             container, ContainerTestUtils.STREAMS_USERNAME, STREAMS_APP_ID, builder.build());
     streams.start();
     try (final TestConsumer consumer =
-        TestConsumer.create(container, ContainerTestUtils.CONSUMER_USERNAME, CONSUMER_GROUP)) {
+        TestConsumer.create(container, consumerUsername, CONSUMER_GROUP)) {
       consumer.consumeForAWhile(
           TOPIC_B,
           (key, value) -> {
@@ -96,8 +116,7 @@ public final class StreamsAclIT {
     assertThat(values).isEmpty();
   }
 
-  @Test
-  public void testStreamWithInternalTopics() {
+  public void streamWithInternalTopics(String consumerUser) {
     final Set<String> values;
     try (final TestProducer producer =
         TestProducer.create(container, ContainerTestUtils.PRODUCER_USERNAME)) {
@@ -117,7 +136,7 @@ public final class StreamsAclIT {
             container, ContainerTestUtils.STREAMS_USERNAME, STREAMS_APP_ID, builder.build());
     streams.start();
     try (final TestConsumer consumer =
-        TestConsumer.create(container, ContainerTestUtils.CONSUMER_USERNAME, CONSUMER_GROUP)) {
+        TestConsumer.create(container, consumerUser, CONSUMER_GROUP)) {
       consumer.consumeForAWhile(
           TOPIC_B,
           (key, value) -> {

--- a/src/test/java/com/purbon/kafka/topology/integration/containerutils/ContainerTestUtils.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/containerutils/ContainerTestUtils.java
@@ -28,6 +28,7 @@ public final class ContainerTestUtils {
   public static final String NO_ACCESS_USERNAME = "no-access-user";
   public static final String PRODUCER_USERNAME = "producer";
   public static final String CONSUMER_USERNAME = "consumer";
+  public static final String BACKUP_USERNAME = "backup-user";
   public static final String OTHER_PRODUCER_USERNAME = "other-producer";
   public static final String OTHER_CONSUMER_USERNAME = "other-consumer";
   public static final String STREAMS_USERNAME = "streamsapp";

--- a/src/test/resources/acl-producer-and-consumer-it.yaml
+++ b/src/test/resources/acl-producer-and-consumer-it.yaml
@@ -18,6 +18,8 @@ projects:
       - principal: "User:other-consumer"
     topics:
       - name: "other-producer-and-consumer-test-topic"
+        metadata:
+          allow-backup: true
         config:
           replication.factor: "1"
           num.partitions: "1"

--- a/src/test/resources/descriptor.yaml
+++ b/src/test/resources/descriptor.yaml
@@ -42,6 +42,8 @@ projects:
               - "topicC"
     streams:
       - principal: "User:App0"
+        metadata:
+          backup-allowed: true
         topics:
           read:
             - "topicA"
@@ -93,6 +95,8 @@ projects:
           value.format: "JSON"
           value.compatibility: "BACKWARD"
         name: "bar"
+        metadata:
+          backup-allowed: true
         config:
           replication.factor: "1"
           num.partitions: "1"

--- a/src/test/resources/integration-tests.properties
+++ b/src/test/resources/integration-tests.properties
@@ -2,3 +2,4 @@ kafka.internal.topic.prefixes.0=_
 topology.topic.prefix.format={{topic}}
 topology.project.prefix.format=
 bootstrap.servers=Ignored. Just to please the config parser.
+julie.backup.principal=User:backup-user

--- a/src/test/resources/streams-acl-it.yaml
+++ b/src/test/resources/streams-acl-it.yaml
@@ -20,6 +20,8 @@ projects:
           replication.factor: "1"
           num.partitions: "1"
       - name: topic-B
+        metadata:
+          allow-backup: true
         config:
           replication.factor: "1"
           num.partitions: "1"


### PR DESCRIPTION
For topics, add:

```yaml
metadata:
  allow-backup: true
```

Then make sure the configuration file contains something like this:

```text
julie.backup.principal=User:backup-user
```

This will give the principal consumer rights on the topic, without having to repeat the principal everywhere backup is wanted.

Rather simple: if a topic is tagged for backup, add the backup principal to the list of consumers before making ACLs.