### PR TITLE
fix(deps): update confluent.version to v8.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -210,7 +210,7 @@
     <assertj.version>3.27.7</assertj.version>
     <aws.java.sdk.version>2.46.17</aws.java.sdk.version>
     <commons.version>1.11.0</commons.version>
-    <confluent.version>8.2.1</confluent.version>
+    <confluent.version>8.3.0</confluent.version>
     <gcp.java.sdk.version>26.84.0</gcp.java.sdk.version>
     <jackson.version>2.22.0</jackson.version>
     <jedis.version>7.5.2</jedis.version>
@@ -220,6 +220,7 @@
     <log4j.version>2.26.0</log4j.version>
     <lombok.version>1.18.46</lombok.version>
     <mockito.version>5.23.0</mockito.version>
+    <protobuf.version>4.34.0</protobuf.version>
     <slf4j.version>2.0.18</slf4j.version>
     <testcontainers.version>2.0.5</testcontainers.version>
     <typesafe.version>1.4.9</typesafe.version>
@@ -268,6 +269,26 @@
       <groupId>io.confluent</groupId>
       <artifactId>kafka-protobuf-provider</artifactId>
       <version>${confluent.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.protobuf</groupId>
+          <artifactId>protobuf-java</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.protobuf</groupId>
+          <artifactId>protobuf-java-util</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>${protobuf.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java-util</artifactId>
+      <version>${protobuf.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>


### PR DESCRIPTION
Without exclusions/inclusions, the upgrade gives the following error in Schema Registry test:

_Detected incompatible Protobuf Gencode/Runtime versions when loading MetaProto: gencode 4.34.0, runtime 4.33.2. Runtime version cannot be older than the linked gencode version._